### PR TITLE
fix: libpng cant generate config for xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,11 +263,17 @@ if(UNIX)
   symbol_prefix()
 endif()
 
-find_program(AWK NAMES gawk awk)
+if(CMAKE_GENERATOR MATCHES "Xcode" AND CMAKE_XCODE_BUILD_SYSTEM MATCHES 12)
+  message(WARNING "libpng does not currently support generating files for multiple targets using the Xcode \"new build system\", libpng will use the prebuilt pnglibconf instead")
+  set(PNG_XCODE_NEW_BUILD_SYSTEM true)
+else()
+  set(PNG_XCODE_NEW_BUILD_SYSTEM false)
+  find_program(AWK NAMES gawk awk)
+endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-if(NOT AWK OR ANDROID OR IOS)
+if (PNG_XCODE_NEW_BUILD_SYSTEM OR NOT AWK OR ANDROID OR IOS)
   # No awk available to generate sources; use pre-built pnglibconf.h
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.h.prebuilt
                  ${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h)
@@ -449,7 +455,7 @@ else()
                             "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.chk"
                             "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.out"
                             "${CMAKE_CURRENT_BINARY_DIR}/scripts/vers.out")
-endif(NOT AWK OR ANDROID OR IOS)
+endif(PNG_XCODE_NEW_BUILD_SYSTEM OR NOT AWK OR ANDROID OR IOS)
 
 # List the source code files.
 set(libpng_public_hdrs
@@ -463,7 +469,7 @@ set(libpng_private_hdrs
     pnginfo.h
     pngstruct.h
 )
-if(AWK AND NOT ANDROID AND NOT IOS)
+if(NOT PNG_XCODE_NEW_BUILD_SYSTEM AND AWK AND NOT ANDROID AND NOT IOS)
   list(APPEND libpng_private_hdrs "${CMAKE_CURRENT_BINARY_DIR}/pngprefix.h")
 endif()
 set(libpng_sources


### PR DESCRIPTION
libpng does not currently support generating files for multiple targets using the Xcode \"new build system\"